### PR TITLE
Honor those who have been here before thee !

### DIFF
--- a/doc/ircd.1m
+++ b/doc/ircd.1m
@@ -1,11 +1,11 @@
 .\" ircd.8/8d/1m 3.0 14 Oct 2019
-.\" syzolin@aspircd.com, informed by nenolod's ircd.8
+.\" ellenor@umbrellix.net & syzolin@aspircd.com, informed by nenolod's ircd.8
 .Dd October 14, 2019
 .Dt IRCD %%MANSECTION%%
 .Os
 .Sh Name
 .Nm ircd
-.Nd the internet relay chat daemon, as modified successively by EFnet, ratbox, AthemeNet and Umbrellix (formerly known as AsterIRC)
+.Nd the internet relay chat daemon, as modified successively by EFnet, ratbox, AthemeNet, Umbrellix (formerly known as AsterIRC), and the AspIRCd project.
 .Sh Synopsis
 .Nm
 .Op Fl foreground
@@ -24,9 +24,9 @@ is to relay messages between its clients, and between its clients and other
 servers.
 This
 .Xr ircd %%MANSECTION%%
-is the AspIRCd ircd, also known as \fBirca\fR after 
-.Dq ircd-nine,
-the former name of the Aspircd IRC network.
+is \fBAspIRCd\fR, the aspircd.com fork of the Umbrellix ircd, which is known as \fBirca\fR after 
+.Dq AsterIRC,
+the former name of the Umbrellix IRC network.
 .Sh Options
 .Bl -tag -width "-w size "
 .It Fl foreground
@@ -75,7 +75,7 @@ Nearly all of the configuration rests in ircd.conf, which is largely self docume
 A small portion rests in ban.db, which you edit from within the Internet Relay Chat program, via a bot or directly through your IRC client.
 You can access the online help for this, once you are an operator, through /quote HELP (the /quote is required as most IRC clients have their own /HELP command).
 .Sh Bugs
-Options specified in ircd.conf (which was imported from the old ircd-chatd we used to develop) have not all been implemented in irca.
+Options specified in ircd.conf (which was imported from the old ircd-chatd Umbrellix used to develop) have not all been implemented in irca, and thus have also not all been implemented in AspIRCd.
 Some may never, and are liable to be removed from that file at any point as they are not part of the configuration spec.
 .Sh Attributes
 See
@@ -84,7 +84,7 @@ if you are on a Solaris or illumos system for a description of the following att
 You do not need to know what this means if you are on any other system.
 For the purpose of this manual page, replace "Sun" in
 .Xr attributes 5
-with "umbrellix.net".
+with "aspircd.com".
 
 Notification of notifiable broken interfaces, should the program expose one in the future, will be via the project webpage if you do not have a support deal with us.
 You still probably do not need to know what any of this means, and indeed, this table may not be correctly formulated; the developers of irca do not believe that software outside of the core system is actually even meant to have an attributes table.


### PR DESCRIPTION
All thou didst was rewrite the manpage to make no sense, Vibhore. I have edited it back to appropriately mention the lineage of the manpage (ellenor@umbrellix.net) as well as the ircd (aspircd is a fork of irca, asterIRC's ircd).

What the hell was that with ircd-nine anyway? Asinine poor grammar and factual incorrectness. Didst thou mandoc|less the page before thou shippedest it?